### PR TITLE
Fix unittests

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,10 +9,13 @@ from unittest.mock import Mock, call, mock_open, patch
 from urllib.parse import urlparse
 from uuid import uuid4
 
+import ops.testing
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
 from charm import AptMirrorCharm
+
+ops.testing.SIMULATE_CAN_CONNECT = True
 
 
 def get_default_charm_configs():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 
 import os
 import random
+import time
 import unittest
 from unittest.mock import Mock, call, mock_open, patch
 from urllib.parse import urlparse
@@ -68,7 +69,9 @@ class TestCharm(BaseTest):
         self.harness.charm._on_update_status(Mock())
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Last sync: Thu Jan  1 00:00:01 1970 " "not published"),
+            BlockedStatus(
+                "Last sync: {} not published".format(time.ctime(os_stat.st_mtime))
+            ),
         )
 
     @patch("os.path.islink")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -104,7 +104,7 @@ class TestCharm(BaseTest):
 
     @patch("builtins.open", new_callable=mock_open)
     def test_cron_schedule_set(self, mock_open_call):
-        schedule = uuid4()
+        schedule = str(uuid4())
         self.harness.update_config({"cron-schedule": schedule})
         mock_open_call.assert_called_with(
             "/etc/cron.d/{}".format(self.harness.charm.model.app.name), "w"


### PR DESCRIPTION
Refactor unittest and also fix unittest failed on Jammy and ops==1.5.3.

Currently, the unit tests is only successful with ops=1.5.2. This patch allows the unit tests to run successfully on Focal and Jammy with latest `ops` (i.e. `ops==1.5.3`)

Focal unittest: https://pastebin.ubuntu.com/p/jZ79M8kbcg/
Jammy unittest: https://pastebin.ubuntu.com/p/WMMtwdfZpp/