### PR TITLE
Fix security issues in delete-snapshot action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -13,7 +13,8 @@ delete-snapshot:
     name:
       description: "Name of the snapshot to delete."
       type: string
-      default: ""
+  required:
+    - name
 publish-snapshot:
   description: Publish snapshot.
   params:

--- a/src/charm.py
+++ b/src/charm.py
@@ -150,6 +150,14 @@ class AptMirrorCharm(CharmBase):
 
     def _on_delete_snapshot_action(self, event):
         snapshot = event.params["name"]
+        if not snapshot.startswith("snapshot-"):
+            event.set_results(
+                {
+                    "ReturnCode": 1,
+                    "Stderr": "Invalid snapshot name: {}".format(snapshot),
+                }
+            )
+            return
         logger.info("Delete snapshot {}".format(snapshot))
         shutil.rmtree("{}/{}".format(self._stored.config["base-path"], snapshot))
         self._update_status()

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -81,9 +81,13 @@ class TestCharmActions:
         results = await helper.run_wait(apt_mirror_unit, cleanup_cmd)
         assert results.get("return-code") == 0
 
-    async def test_delete_snapshot_action(self, apt_mirror_unit, base_path, helper):
+    @pytest.mark.parametrize(
+        "name,expected_code", [("snapshot-deleteme", 0), ("random-name", 1)]
+    )
+    async def test_delete_snapshot_action(
+        self, name, expected_code, apt_mirror_unit, base_path, helper
+    ):
         """Test delete_snapshot action."""
-        name = "snapshot-deleteme"
         create_cmd = "mkdir {}/{}".format(base_path, name)
         check_cmd = "find {}/{}".format(base_path, name)
 
@@ -93,10 +97,14 @@ class TestCharmActions:
         results = await helper.run_action_wait(
             apt_mirror_unit, "delete-snapshot", name=name
         )
-        assert results.get("return-code") == 0
+        assert results.get("return-code") == expected_code
 
-        results = await helper.run_wait(apt_mirror_unit, check_cmd)
-        assert results.get("return-code") != 0
+        if expected_code == 1:
+            results = await helper.run_wait(apt_mirror_unit, check_cmd)
+            assert results.get("return-code") == 0
+        else:
+            results = await helper.run_wait(apt_mirror_unit, check_cmd)
+            assert results.get("return-code") != 0
 
     async def test_list_snapshots_action(self, apt_mirror_unit, helper):
         """Test list snapshots action."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -456,8 +456,8 @@ class TestCharm(BaseTest):
         )
 
     @patch("shutil.rmtree")
-    def test_delete_snapshot_action(self, shutil_rmtree):
-        snapshot_name = uuid4()
+    def test_delete_snapshot_action_success(self, shutil_rmtree):
+        snapshot_name = "snapshot-19700101"
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._on_delete_snapshot_action(
             Mock(params={"name": snapshot_name})
@@ -466,6 +466,16 @@ class TestCharm(BaseTest):
             shutil_rmtree.call_args,
             call("{}/{}".format(self.harness.model.config["base-path"], snapshot_name)),
         )
+
+    @patch("shutil.rmtree")
+    def test_delete_snapshot_action_failure(self, shutil_rmtree):
+        for snapshot_name in ["", str(uuid4())]:
+            with self.subTest(name=snapshot_name):
+                self.harness.charm._get_snapshot_name = Mock()
+                self.harness.charm._on_delete_snapshot_action(
+                    Mock(params={"name": snapshot_name})
+                )
+                shutil_rmtree.assert_not_called()
 
     @patch("os.path.isdir")
     @patch("os.path.islink")


### PR DESCRIPTION
The user is currently able to delete the root filesystem "/" or some other important directory, using the delete-snapshot action with carefully crafted config options. This is because the delete-snapshot action will remove {base-path}/{name}, and both of these parameters can be configured by the user. 

This patch fixes this security issue.