### PR TITLE
Minor bug fixes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -266,12 +266,7 @@ class AptMirrorCharm(CharmBase):
     def _on_delete_snapshot_action(self, event):
         snapshot = event.params["name"]
         if not snapshot.startswith("snapshot-"):
-            event.set_results(
-                {
-                    "ReturnCode": 1,
-                    "Stderr": "Invalid snapshot name: {}".format(snapshot),
-                }
-            )
+            event.fail("Invalid snapshot name: {}".format(snapshot))
             return
         logger.info("Delete snapshot {}".format(snapshot))
         shutil.rmtree("{}/{}".format(self._stored.config["base-path"], snapshot))

--- a/src/charm.py
+++ b/src/charm.py
@@ -84,6 +84,22 @@ class AptMirrorCharm(CharmBase):
         subprocess.check_output(["apt", "install", "-y", "apt-mirror"])
 
     def _patch_config(self, current_config):
+        """Patch configuration options.
+
+        Some config options need to be obtained from the input config options.
+        Therefore, this internal function processes the input configuration
+        option, and adds additional options for the charm; the added options
+        should be connected with "_", for example, http_proxy and https_proxy.
+
+        Args:
+            current_config: Current config options.
+
+        Returns:
+            config: Additional configuration options
+
+        Raises:
+            ValueError: If `_validate_mirror_list` failed.
+        """
         config = {}
         proxy_settings = {
             "JUJU_CHARM_HTTP_PROXY": "http_proxy",
@@ -109,6 +125,7 @@ class AptMirrorCharm(CharmBase):
         try:
             patched_config = self._patch_config(self._stored.config)
         except ValueError as err:
+            # if _validate_mirror_list failed, set the unit to blocked state.
             self.model.unit.status = BlockedStatus(str(err))
         else:
             change_set.update(patched_config)


### PR DESCRIPTION
- Fix potential bugs in mirror-list option: an empty line is inserted between two mirror-lists, and not enough information is provided in a mirror list (i.e. at least contain <deb> <uri> <distro>).
- Fix incorrect the use of event.set_results(), we should use event.fail() to mark the execution of an action failed.