### PR TITLE
tests/functional: pin juju<3

### DIFF
--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,0 +1,1 @@
+juju<3  # https://bugs.launchpad.net/bugs/2007834

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -259,7 +259,6 @@ deb fake-uri fake-distro\
     def test_create_snapshot_action(
         self, os_makedirs, os_symlink, os_path_exists, shutil_copytree, os_walk
     ):
-
         with patch("builtins.open", new_callable=mock_open):
             self.harness.update_config(
                 {


### PR DESCRIPTION
We are running functests against juju controller `2.x` for now, new libjuju versioning is in agreement with controller version.

Also run reformat to make the linter happy