### PR TITLE
refined functions to get packages indices

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,4 +21,4 @@ jobs:
       python-version-func: "3.10"
       tox-version: "<4"
       juju-channel: "3.1/stable"
-      commands: "['FUNC_ARGS=\"--series bionic\" make functional', 'FUNC_ARGS=\"--series focal\" make functional', 'FUNC_ARGS=\"--series jammy\" make functional']"
+      commands: "['FUNC_ARGS=\"--series focal\" make functional', 'FUNC_ARGS=\"--series jammy\" make functional']"

--- a/actions.yaml
+++ b/actions.yaml
@@ -38,14 +38,18 @@ publish-snapshot:
       default: ""
 check-packages:
   description: |
-    Check and report the packages that are no longer referenced in the existing
+    DEPRECATED: Check and report the packages that are no longer referenced in the existing
     snapshots and the mirror path.
+    # Note(rgildein): The synchronize action is already cleaning up outed packages from
+    mirror path and snapshot are using hard links, so this action should always return empty list.
 clean-up-packages:
   description: |
-    Remove the packages reported in the check-packages action. You must provide
+    DEPRECATED: Remove the packages reported in the check-packages action. You must provide
     a parameter 'confirm=true' to actually perform the action; 'confirm=false'
     will abort the action. If you are not sure, please use `check-packages`
     action to view what pacakges can be removed.
+    # Note(rgildein): The synchronize action is already cleaning up outed packages from
+    mirror path and snapshot are using hard links, so this action should not remove anything.
   params:
     confirm:
       description: "Confirm that you really want to perform this action."

--- a/src/charm.py
+++ b/src/charm.py
@@ -55,16 +55,21 @@ class AptMirrorCharm(CharmBase):
 
         self._stored.set_default(config={})
 
+    @property
+    def base_path(self) -> Path:
+        """Return base-path."""
+        return Path(self._stored.config["base-path"])
+
     def _on_publish_relation_joined(self, event):
-        publish_path = "{}/publish".format(self._stored.config["base-path"])
-        event.relation.data[self.model.unit].update({"path": publish_path})
+        publish_path = self.base_path / "publish"
+        event.relation.data[self.model.unit].update({"path": str(publish_path)})
 
     def _update_status(self):
         published_snapshot = self._get_published_snapshot()
         if published_snapshot:
             self.model.unit.status = ActiveStatus("Publishes: {}".format(published_snapshot))
         else:
-            path = self._stored.config["base-path"] + "/mirror"
+            path = self.base_path / "mirror"
             if os.path.isdir(path):
                 stat = os.stat(path)
                 self.model.unit.status = BlockedStatus(
@@ -149,7 +154,7 @@ class AptMirrorCharm(CharmBase):
         # and should not be removed.
         indexed_packages = set()
         snapshot_paths = self._list_snapshots()
-        mirror_path = "{}/mirror".format(self._stored.config["base-path"])
+        mirror_path = self.base_path / "mirror"
         for path in snapshot_paths + [mirror_path]:
             for base, indices in locate_package_indices(path):
                 indexed_packages |= set(find_packages_by_indices(indices, base=base))
@@ -249,7 +254,7 @@ class AptMirrorCharm(CharmBase):
         try:
             if mirror_filter is None:
                 # clean dists only if no filter was applied
-                clean_dists(Path(self._stored.config["base-path"]))
+                clean_dists(self.base_path)
 
             logger.info("running apt-mirror for:%s", os.linesep + os.linesep.join(mirrors))
             tmp_path = self._create_tmp_apt_mirror_config(*mirrors)
@@ -278,30 +283,31 @@ class AptMirrorCharm(CharmBase):
     def _on_create_snapshot_action(self, event):
         snapshot_name = self._get_snapshot_name()
         logger.info("Create snapshot {}".format(snapshot_name))
-        snapshot_name_path = "{}/{}".format(self._stored.config["base-path"], snapshot_name)
-        mirror_path = "{}/mirror".format(self._stored.config["base-path"])
+        snapshot_name_path = self.base_path / snapshot_name
+        mirror_path = self.base_path / "mirror"
         mirrors = self._mirror_names()
         if not os.path.exists(snapshot_name_path):
             os.makedirs(snapshot_name_path)
         for dirpath, dirs, files in os.walk(mirror_path):
             if "pool" in dirs:
-                src_root = dirpath
-                src_pool = "{}/pool".format(src_root)
+                src_root = Path(dirpath)
+                src_pool = src_root / "pool"
                 subtree = self._build_subtree(mirrors, src_root, mirror_path)
-                dst_root = "{}/{}".format(snapshot_name_path, subtree)
-                dst_pool = "{}/pool".format(dst_root)
+                dst_root = snapshot_name_path / subtree
+                dst_pool = dst_root / "pool"
                 os.makedirs(dst_root, exist_ok=True)
-                os.symlink(src_pool, dst_pool)
-                logger.info("{} -> {}".format(src_pool, dst_pool))
+                # Note(rgildein): Copy directories and for all files in it creates hard link.
+                shutil.copytree(src_pool, dst_pool, copy_function=os.link)
+                logger.info("%s -> %s", src_pool, dst_pool)
             if "dists" in dirs:
-                src_root = dirpath
-                src_dists = "{}/dists".format(src_root)
+                src_root = Path(dirpath)
+                src_dists = src_root / "dists"
                 subtree = self._build_subtree(mirrors, src_root, mirror_path)
-                dst_root = "{}/{}".format(snapshot_name_path, subtree)
-                dst_dists = "{}/dists".format(dst_root)
+                dst_root = snapshot_name_path / subtree
+                dst_dists = dst_root / "dists"
                 os.makedirs(dst_root, exist_ok=True)
                 shutil.copytree(src_dists, dst_dists)
-                logger.info("{} -> {}".format(src_dists, dst_dists))
+                logger.info("%s -> %s", src_dists, dst_dists)
         self._update_status()
 
     def _on_delete_snapshot_action(self, event):
@@ -310,11 +316,11 @@ class AptMirrorCharm(CharmBase):
             event.fail("Invalid snapshot name: {}".format(snapshot))
             return
         logger.info("Delete snapshot {}".format(snapshot))
-        shutil.rmtree("{}/{}".format(self._stored.config["base-path"], snapshot))
+        shutil.rmtree(self.base_path / snapshot)
         self._update_status()
 
     def _list_snapshots(self):
-        return list(Path(self._stored.config["base-path"]).glob("snapshot-*"))
+        return list(self.base_path.glob("snapshot-*"))
 
     def _on_list_snapshots_action(self, event):
         snapshots = [p.name for p in self._list_snapshots()]
@@ -324,8 +330,8 @@ class AptMirrorCharm(CharmBase):
     def _on_publish_snapshot_action(self, event):
         name = event.params["name"]
         logger.info("Publish snapshot {}".format(name))
-        snapshot_path = "{}/{}".format(self._stored.config["base-path"], name)
-        publish_path = "{}/publish".format(self._stored.config["base-path"])
+        snapshot_path = self.base_path / name
+        publish_path = self.base_path / "publish"
         if not os.path.isdir(snapshot_path):
             event.fail("Snapshot does not exist")
             return
@@ -376,7 +382,7 @@ class AptMirrorCharm(CharmBase):
         ]
 
     def _get_published_snapshot(self):
-        publish_path = "{}/publish".format(self._stored.config["base-path"])
+        publish_path = self.base_path / "publish"
         if os.path.islink(publish_path):
             return os.path.basename(os.readlink(publish_path))
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -355,10 +355,9 @@ deb fake-uri fake-distro\
     @patch("os.walk")
     @patch("shutil.copytree")
     @patch("os.path.exists")
-    @patch("os.symlink")
     @patch("os.makedirs")
     def test_create_snapshot_action(
-        self, os_makedirs, os_symlink, os_path_exists, shutil_copytree, os_walk, _
+        self, os_makedirs, os_path_exists, shutil_copytree, os_walk, _
     ):
         self.harness.update_config(
             {
@@ -367,7 +366,7 @@ deb fake-uri fake-distro\
             }
         )
         default_config = self.harness.model.config
-        rand_subdir = random.randint(10, 100)
+        rand_subdir = str(random.randint(10, 100))
         upstream_path = "{}".format(uuid4())
         mirror_url = default_config["mirror-list"].split()[1]
         mirror_host = urlparse(mirror_url).hostname
@@ -385,60 +384,41 @@ deb fake-uri fake-distro\
         )
         os_path_exists.return_value = False
 
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._get_snapshot_name.return_value = snapshot_name
         self.harness.charm._on_create_snapshot_action(Mock())
-        self.assertTrue(os_symlink.called)
-        self.assertTrue(os_makedirs.called)
-        self.assertTrue(shutil_copytree.called)
-        self.assertEqual(
-            os_symlink.call_args,
-            call(
-                "{}/{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    snapshot_name,
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-            ),
+        exp_src_root = (
+            self.harness.charm.base_path / "mirror" / mirror_host / upstream_path / rand_subdir
         )
-        self.assertEqual(
-            shutil_copytree.call_args,
-            call(
-                "{}/{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    snapshot_name,
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-            ),
+        exp_dst_root = (
+            self.harness.charm.base_path
+            / snapshot_name
+            / mirror_host
+            / upstream_path
+            / rand_subdir
+        )
+        os_makedirs.assert_has_calls(
+            [
+                call(self.harness.charm.base_path / snapshot_name),
+                call(exp_dst_root, exist_ok=True),
+                call(exp_dst_root, exist_ok=True),
+            ]
+        )
+        shutil_copytree.assert_has_calls(
+            [
+                call(exp_src_root / "pool", exp_dst_root / "pool", copy_function=os.link),
+                call(exp_src_root / "dists", exp_dst_root / "dists"),
+            ]
         )
 
     @patch("charm.open", new_callable=mock_open)
     @patch("os.walk")
     @patch("shutil.copytree")
     @patch("os.path.exists")
-    @patch("os.symlink")
     @patch("os.makedirs")
     def test_create_snapshot_action_strip_mirrors(
-        self, os_makedirs, os_symlink, os_path_exists, shutil_copytree, os_walk, _
+        self, os_makedirs, os_path_exists, shutil_copytree, os_walk, _
     ):
         self.harness.update_config(
             {
@@ -448,7 +428,7 @@ deb fake-uri fake-distro\
         )
         default_config = self.harness.model.config
 
-        rand_subdir = random.randint(10, 100)
+        rand_subdir = str(random.randint(10, 100))
         upstream_path = "{}".format(uuid4())
         mirror_url = default_config["mirror-list"].split()[1]
         mirror_host = urlparse(mirror_url).hostname
@@ -466,58 +446,35 @@ deb fake-uri fake-distro\
         )
         os_path_exists.return_value = False
 
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._get_snapshot_name.return_value = snapshot_name
         self.harness.charm._on_create_snapshot_action(Mock())
-        self.assertTrue(os_symlink.called)
-        self.assertTrue(os_makedirs.called)
-        self.assertTrue(shutil_copytree.called)
-        self.assertEqual(
-            os_symlink.call_args,
-            call(
-                "{}/{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    snapshot_name,
-                    upstream_path,
-                    rand_subdir,
-                ),
-            ),
+        exp_src_root = (
+            self.harness.charm.base_path / "mirror" / mirror_host / upstream_path / rand_subdir
         )
-        self.assertEqual(
-            shutil_copytree.call_args,
-            call(
-                "{}/{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    snapshot_name,
-                    upstream_path,
-                    rand_subdir,
-                ),
-            ),
+        exp_dst_root = self.harness.charm.base_path / snapshot_name / upstream_path / rand_subdir
+        os_makedirs.assert_has_calls(
+            [
+                call(self.harness.charm.base_path / snapshot_name),
+                call(exp_dst_root, exist_ok=True),
+                call(exp_dst_root, exist_ok=True),
+            ]
+        )
+        shutil_copytree.assert_has_calls(
+            [
+                call(exp_src_root / "pool", exp_dst_root / "pool", copy_function=os.link),
+                call(exp_src_root / "dists", exp_dst_root / "dists"),
+            ]
         )
 
     @patch("charm.open", new_callable=mock_open)
     @patch("os.walk")
     @patch("shutil.copytree")
     @patch("os.path.exists")
-    @patch("os.symlink")
     @patch("os.makedirs")
     def test_create_snapshot_action_strip_path(
-        self, os_makedirs, os_symlink, os_path_exists, shutil_copytree, os_walk, _
+        self, os_makedirs, os_path_exists, shutil_copytree, os_walk, _
     ):
         upstream_path = "{}".format(uuid4())
         self.harness.update_config(
@@ -529,7 +486,7 @@ deb fake-uri fake-distro\
         )
         default_config = self.harness.model.config
 
-        rand_subdir = random.randint(10, 100)
+        rand_subdir = str(random.randint(10, 100))
         mirror_url = default_config["mirror-list"].split()[1]
         mirror_host = urlparse(mirror_url).hostname
         mirror_path = "{}/mirror".format(default_config["base-path"])
@@ -546,42 +503,26 @@ deb fake-uri fake-distro\
         )
         os_path_exists.return_value = False
 
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._get_snapshot_name.return_value = snapshot_name
         self.harness.charm._on_create_snapshot_action(Mock())
-        self.assertTrue(os_symlink.called)
-        self.assertTrue(os_makedirs.called)
-        self.assertTrue(shutil_copytree.called)
-        self.assertEqual(
-            os_symlink.call_args,
-            call(
-                "{}/{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/pool".format(
-                    default_config["base-path"], snapshot_name, mirror_host, rand_subdir
-                ),
-            ),
+        exp_src_root = (
+            self.harness.charm.base_path / "mirror" / mirror_host / upstream_path / rand_subdir
         )
-        self.assertEqual(
-            shutil_copytree.call_args,
-            call(
-                "{}/{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/dists".format(
-                    default_config["base-path"], snapshot_name, mirror_host, rand_subdir
-                ),
-            ),
+        exp_dst_root = self.harness.charm.base_path / snapshot_name / mirror_host / rand_subdir
+        os_makedirs.assert_has_calls(
+            [
+                call(self.harness.charm.base_path / snapshot_name),
+                call(exp_dst_root, exist_ok=True),
+                call(exp_dst_root, exist_ok=True),
+            ]
+        )
+        shutil_copytree.assert_has_calls(
+            [
+                call(exp_src_root / "pool", exp_dst_root / "pool", copy_function=os.link),
+                call(exp_src_root / "dists", exp_dst_root / "dists"),
+            ]
         )
 
     def test_list_snapshots_action(self):
@@ -602,10 +543,7 @@ deb fake-uri fake-distro\
         snapshot_name = "snapshot-19700101"
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._on_delete_snapshot_action(Mock(params={"name": snapshot_name}))
-        self.assertEqual(
-            shutil_rmtree.call_args,
-            call("{}/{}".format(self.harness.model.config["base-path"], snapshot_name)),
-        )
+        shutil_rmtree.assert_called_once_with(self.harness.charm.base_path / snapshot_name)
 
     @patch("shutil.rmtree")
     def test_delete_snapshot_action_failure(self, shutil_rmtree):
@@ -630,17 +568,13 @@ deb fake-uri fake-distro\
         os_path_islink,
         os_path_isdir,
     ):
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         os_path_islink.return_value = True
-        base_path = self.harness.charm._stored.config["base-path"]
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._on_publish_snapshot_action(Mock(params={"name": snapshot_name}))
-        self.assertEqual(
-            os_symlink.call_args,
-            call(
-                "{}/{}".format(base_path, snapshot_name),
-                "{}/publish".format(base_path),
-            ),
+        os_symlink.assert_called_once_with(
+            self.harness.charm.base_path / snapshot_name,
+            self.harness.charm.base_path / "publish",
         )
 
     @patch("os.path.isdir")
@@ -650,7 +584,7 @@ deb fake-uri fake-distro\
     def test_publish_snapshot_action_fail(
         self, os_unlink, os_symlink, os_path_islink, os_path_isdir
     ):
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         os_path_isdir.return_value = False
         action_event = Mock(params={"name": snapshot_name})
         self.harness.charm._get_snapshot_name = Mock()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -49,6 +49,60 @@ def test_clean_packages(packages, exp_result):
         package.unlink.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "paths, exp_indices",
+    [
+        (
+            [
+                "bionic-backports/universe/binary-amd64/Packages.xz",
+                "bionic-backports/universe/binary-amd64/Packages.gz",
+                "bionic-backports/universe/binary-amd64/Packages",
+                "bionic-backports/main/binary-amd64/Packages.xz",
+                "bionic-backports/main/binary-amd64/Packages.gz",
+                "bionic-backports/main/binary-amd64/Packages",
+                "bionic-backports/multiverse/binary-amd64/Packages.xz",
+                "bionic-backports/multiverse/binary-amd64/Packages.gz",
+                "bionic-backports/multiverse/binary-amd64/Packages",
+                "bionic-backports/restricted/binary-amd64/Packages.xz",
+                "bionic-backports/restricted/binary-amd64/Packages.gz",
+                "bionic-backports/restricted/binary-amd64/Packages",
+                "focal-backports/universe/binary-amd64/Packages.xz",
+                "focal-backports/universe/binary-amd64/Packages.gz",
+                "focal-backports/universe/binary-amd64/Packages",
+                "focal-backports/main/binary-amd64/Packages.xz",
+                "focal-backports/main/binary-amd64/Packages.gz",
+                "focal-backports/main/binary-amd64/Packages",
+                "focal-backports/multiverse/binary-amd64/Packages.xz",
+                "focal-backports/multiverse/binary-amd64/Packages.gz",
+                "focal-backports/multiverse/binary-amd64/Packages",
+                "focal-backports/restricted/binary-amd64/Packages.xz",
+                "focal-backports/restricted/binary-amd64/Packages.gz",
+                "focal-backports/restricted/binary-amd64/Packages",
+            ],
+            [
+                "bionic-backports/main/binary-amd64/Packages",
+                "bionic-backports/multiverse/binary-amd64/Packages",
+                "bionic-backports/restricted/binary-amd64/Packages",
+                "bionic-backports/universe/binary-amd64/Packages",
+                "focal-backports/main/binary-amd64/Packages",
+                "focal-backports/multiverse/binary-amd64/Packages",
+                "focal-backports/restricted/binary-amd64/Packages",
+                "focal-backports/universe/binary-amd64/Packages",
+            ],
+        )
+    ],
+)
+def test_get_package_indices(tmp_path, paths, exp_indices):
+    """Test helper function to obtain package indices from dists directory."""
+    dists = tmp_path / "dists"
+    for path in paths:
+        _path = dists / path
+        _path.mkdir(parents=True, exist_ok=True)
+        _path.touch()
+
+    assert utils._get_package_indices(dists) == [dists / indice for indice in exp_indices]
+
+
 class TestUtils(unittest.TestCase):
     def test_find_packages_by_indices(self):
         """Test find_packages_by_indices on a sample mirror path."""


### PR DESCRIPTION
Add the _get_package_indices, which is searching all "**/Packages*" in dists, but instead of picking up only the first path, it's filtering a path from the same parent directory.

e.g.
```python
# from
[
  "bionic-backports/universe/binary-amd64/Packages.xz",
  "bionic-backports/universe/binary-amd64/Packages.gz",
  "bionic-backports/universe/binary-amd64/Packages",
  "bionic-backports/main/binary-amd64/Packages.xz",
  "bionic-backports/main/binary-amd64/Packages.gz",
  "bionic-backports/main/binary-amd64/Packages",
]
# to
[
  "bionic-backports/main/binary-amd64/Packages",  
  "bionic-backports/universe/binary-amd64/Packages",
]
```