### PR TITLE
drop bionic support

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,4 +21,4 @@ jobs:
       python-version-func: "3.10"
       tox-version: "<4"
       juju-channel: "3.1/stable"
-      commands: "['FUNC_ARGS=\"--series bionic\" make functional', 'FUNC_ARGS=\"--series focal\" make functional', 'FUNC_ARGS=\"--series jammy\" make functional']"
+      commands: "['FUNC_ARGS=\"--series focal\" make functional', 'FUNC_ARGS=\"--series jammy\" make functional']"

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The charm can be deployed using `Juju`:
 juju deploy apt-mirror
 ```
 
-The charm can handle arbitrary set of upstream DEB sources via setting `mirror-list`. Example below shows a bundle with this charm configured to mirror multiple Ubuntu series (Bionic and Focal) in a single repository and expose this repository via NGINX. Additionally PPAs and external repositories can be mirrored.
+The charm can handle arbitrary set of upstream DEB sources via setting `mirror-list`. Example below shows a bundle with this charm configured to mirror multiple Ubuntu series (Focal and Jammy) in a single repository and expose this repository via NGINX. Additionally PPAs and external repositories can be mirrored.
 ```
-series: bionic
+series: jammy
 machines:
   '0':
-    series: bionic
+    series: jammy
 services:
   nginx:
     charm: nginx
@@ -34,14 +34,14 @@ services:
     num_units: 1
     options:
       mirror-list: |-
-        deb http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse
-        deb http://archive.ubuntu.com/ubuntu bionic-updates main restricted universe multiverse
-        deb http://archive.ubuntu.com/ubuntu bionic-backports main restricted universe multiverse
-        deb http://security.ubuntu.com/ubuntu bionic-security main restricted universe multiverse
         deb http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse
         deb http://archive.ubuntu.com/ubuntu focal-updates main restricted universe multiverse
         deb http://archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
         deb http://security.ubuntu.com/ubuntu focal-security main restricted universe multiverse
+        deb http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
+        deb http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse
+        deb http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
+        deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
     to:
     - '0'
 relations:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -18,7 +18,3 @@ bases:
           channel: "20.04"
           architectures:
               - amd64
-        - name: ubuntu
-          channel: "18.04"
-          architectures:
-              - amd64

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@
 options:
   mirror-list:
     default: |-
-      deb http://archive.ubuntu.com/ubuntu bionic main restricted universe multiverse
+      deb http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
     description: A list of repositories to mirror.
     type: string
   base-path:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-# remain compatible with bionic
-ops < 2.0
+ops
 jinja2

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -208,7 +208,7 @@ class TestCharm:
         url = "ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu"
         mirror_list = """\
 deb https://{0} focal main
-deb https://{0} bionic main\
+deb https://{0} jammy main\
 """.format(
             url
         )
@@ -237,7 +237,7 @@ deb https://{0} bionic main\
         url = "ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu"
         mirror_list = """\
 deb https://{0} focal main
-deb https://{0} bionic main\
+deb https://{0} jammy main\
 """.format(
             url
         )
@@ -261,7 +261,7 @@ deb https://{0} bionic main\
         # Note these can be changed if you changed the test url and mirror_list
         test_apts = """\
 deb http://{0}/apt-mirror/{1} focal main
-deb http://{0}/apt-mirror/{1} bionic main\
+deb http://{0}/apt-mirror/{1} jammy main\
 """.format(
             nginx_public_ip, url
         )
@@ -290,8 +290,8 @@ deb http://{0}/apt-mirror/{1} bionic main\
 
         # Start with 2 mirror lists.
         mirror_list = """\
-deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
-deb http://ppa.launchpad.net/landscape/19.10/ubuntu bionic main\
+deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu jammy main
+deb http://ppa.launchpad.net/landscape/21.10/ubuntu focal main\
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])
@@ -299,7 +299,7 @@ deb http://ppa.launchpad.net/landscape/19.10/ubuntu bionic main\
 
         # End up with 1 mirror lists.
         mirror_list = """\
-deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
+deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu jammy main
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])
@@ -328,7 +328,7 @@ deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal mai
         # Start with 2 mirror lists.
         mirror_list = """\
 deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
-deb http://ppa.launchpad.net/landscape/19.10/ubuntu bionic main\
+deb http://ppa.launchpad.net/landscape/19.10/ubuntu focal main\
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])
@@ -417,15 +417,15 @@ deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal mai
 
         # Start with a test mirror
         mirror_list = """\
-deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu bionic main
+deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])
         await apt_mirror_unit.run_action("synchronize")
 
-        # Upgrade the distro to focal
+        # Upgrade the distro to Jammy
         mirror_list = """\
-deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
+deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu jammy main
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])
@@ -437,17 +437,17 @@ deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal mai
         count = int(results.get("count"))
         assert count == 0
 
-        # Let's switch back to bionic and create a snapshot before switching to
+        # Let's switch back to Focal and create a snapshot before switching to
         # focal.
         mirror_list = """\
-deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu bionic main
+deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])
         await apt_mirror_unit.run_action("synchronize")
         await helper.run_action_wait(apt_mirror_unit, "create-snapshot")
         mirror_list = """\
-deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
+deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu jammy main
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])

--- a/tests/functional/test_charm.py
+++ b/tests/functional/test_charm.py
@@ -208,7 +208,7 @@ class TestCharm:
         url = "ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu"
         mirror_list = """\
 deb https://{0} focal main
-deb https://{0} jammy main\
+deb https://{0} bionic main\
 """.format(
             url
         )
@@ -237,7 +237,7 @@ deb https://{0} jammy main\
         url = "ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu"
         mirror_list = """\
 deb https://{0} focal main
-deb https://{0} jammy main\
+deb https://{0} bionic main\
 """.format(
             url
         )
@@ -261,7 +261,7 @@ deb https://{0} jammy main\
         # Note these can be changed if you changed the test url and mirror_list
         test_apts = """\
 deb http://{0}/apt-mirror/{1} focal main
-deb http://{0}/apt-mirror/{1} jammy main\
+deb http://{0}/apt-mirror/{1} bionic main\
 """.format(
             nginx_public_ip, url
         )
@@ -291,7 +291,7 @@ deb http://{0}/apt-mirror/{1} jammy main\
         # Start with 2 mirror lists.
         mirror_list = """\
 deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu jammy main
-deb http://ppa.launchpad.net/landscape/21.10/ubuntu focal main\
+deb http://ppa.launchpad.net/landscape/self-hosted-23.10/ubuntu jammy main\
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])
@@ -328,7 +328,7 @@ deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu jammy mai
         # Start with 2 mirror lists.
         mirror_list = """\
 deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
-deb http://ppa.launchpad.net/landscape/19.10/ubuntu focal main\
+deb http://ppa.launchpad.net/landscape/self-hosted-23.10/ubuntu jammy main\
 """
         await apt_mirror_app.set_config({"mirror-list": mirror_list})
         await ops_test.model.wait_for_idle(apps=["apt-mirror"])
@@ -438,7 +438,7 @@ deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu jammy mai
         assert count == 0
 
         # Let's switch back to Focal and create a snapshot before switching to
-        # focal.
+        # Jammy.
         mirror_list = """\
 deb https://ppa.launchpadcontent.net/canonical-bootstack/public/ubuntu focal main
 """

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -156,7 +156,7 @@ deb fake-uri fake-distro\
     @patch("charm.open", new_callable=mock_open)
     def test_apt_mirror_list(self, mocked_open):
         url = "http://archive.ubuntu.com/ubuntu"
-        opts = "bionic main restricted universe multiverse"
+        opts = "jammy main restricted universe multiverse"
         self.harness.update_config({"mirror-list": "deb {} {}".format(url, opts)})
         mocked_open.assert_called_with(Path("/etc/apt/mirror.list"), "wb")
         mocked_open().write.assert_called_once_with(


### PR DESCRIPTION
The functional tests are failing for Bionic series, and since we do not need to support it anymore. 