### PR TITLE
refined functions to get packages indices

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -5,12 +5,8 @@
 
 import logging
 import shutil
-from bz2 import open as bopen
-from gzip import open as gopen
-from lzma import open as lopen
-from os import readlink
 from pathlib import Path
-from typing import Set
+from typing import List, Set
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +54,26 @@ def find_packages_by_indices(indices, base=""):
     return packages
 
 
+def _get_archive_root(pool: Path) -> Path:
+    """Get arive path from pool path."""
+    if pool.is_symlink():
+        return pool.readlink().parent.absolute()
+
+    return pool.parent.absolute()
+
+
+def _get_package_indices(dists: Path) -> List[Path]:
+    """Get package indeces."""
+    indices, parents = [], []
+    # filter files from same parent directory
+    for path in sorted(dists.glob("**/Packages*")):
+        if path.parent not in parents:
+            indices.append(path)
+            parents.append(path.parent)
+
+    return indices
+
+
 def locate_package_indices(path):
     """Return all locations of the index files.
 
@@ -74,16 +90,13 @@ def locate_package_indices(path):
     if not path.exists():
         raise FileNotFoundError("Invalid path: {}".format(path))
 
-    dists = list(path.glob("**/dists"))
-    pool = [d.parent / "pool" for d in dists]
-
     archive_roots = []
     package_indices = []
-    for p, d in zip(pool, dists):
-        archive_roots.append(
-            Path(readlink(p)).parent.absolute() if p.is_symlink() else p.parent.absolute()
-        )
-        package_indices.append([sorted(distro.glob("**/Packages*"))[0] for distro in d.glob("*")])
+    for dists in path.glob("**/dists"):
+        pool = dists.parent / "pool"
+        archive_roots.append(_get_archive_root(pool))
+        package_indices.append(_get_package_indices(dists))
+
     return zip(archive_roots, package_indices)
 
 
@@ -98,7 +111,10 @@ def convert_bytes(num):
 def _locate_packages_from_index(package_index, archive_root=""):
     """Return an unique set of path-to-packages found in the index file."""
     opener = _get_opener(package_index)
-    with opener(package_index, mode="r") as f:
+
+    # Note (rgildein): We need to use `rt` directly, because `r` for gzip is referring
+    # to `rb` instead of `rt`.
+    with opener(package_index, mode="rt") as f:
         packages = {
             Path(archive_root, line.strip().replace("Filename: ", ""))
             for line in f
@@ -111,10 +127,16 @@ def _get_opener(path):
     """Return appropriate opener to open an index file."""
     extension = Path(path).suffix
     if extension == ".gz":
-        return gopen
+        import gzip
+
+        return gzip.open
     elif extension == ".bz2":
-        return bopen
+        import bz2
+
+        return bz2.open
     elif extension == ".lzma" or extension == ".xz":
-        return lopen
+        import lzma
+
+        return lzma.open
     else:
         return open

--- a/src/utils.py
+++ b/src/utils.py
@@ -55,7 +55,7 @@ def find_packages_by_indices(indices, base=""):
 
 
 def _get_archive_root(pool: Path) -> Path:
-    """Get arive path from pool path."""
+    """Get archive path from pool path."""
     if pool.is_symlink():
         return pool.readlink().parent.absolute()
 
@@ -63,7 +63,7 @@ def _get_archive_root(pool: Path) -> Path:
 
 
 def _get_package_indices(dists: Path) -> List[Path]:
-    """Get package indeces."""
+    """Get package indices."""
     indices, parents = [], []
     # filter files from same parent directory
     for path in sorted(dists.glob("**/Packages*")):

--- a/src/utils.py
+++ b/src/utils.py
@@ -57,7 +57,9 @@ def find_packages_by_indices(indices, base=""):
 def _get_archive_root(pool: Path) -> Path:
     """Get archive path from pool path."""
     if pool.is_symlink():
-        return pool.readlink().parent.absolute()
+        # Note(rgildein): using pool.resolve instead of pool.readlink, since readlink was
+        # introduced in Python 3.9, we know that path exists, so it's safe
+        return pool.resolve().parent.absolute()
 
     return pool.parent.absolute()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -367,7 +367,7 @@ deb fake-uri fake-distro\
             }
         )
         default_config = self.harness.model.config
-        rand_subdir = random.randint(10, 100)
+        rand_subdir = str(random.randint(10, 100))
         upstream_path = "{}".format(uuid4())
         mirror_url = default_config["mirror-list"].split()[1]
         mirror_host = urlparse(mirror_url).hostname
@@ -385,51 +385,29 @@ deb fake-uri fake-distro\
         )
         os_path_exists.return_value = False
 
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._get_snapshot_name.return_value = snapshot_name
         self.harness.charm._on_create_snapshot_action(Mock())
-        self.assertTrue(os_symlink.called)
-        self.assertTrue(os_makedirs.called)
-        self.assertTrue(shutil_copytree.called)
-        self.assertEqual(
-            os_symlink.call_args,
-            call(
-                "{}/{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    snapshot_name,
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-            ),
+        exp_src_root = (
+            self.harness.charm.base_path / "mirror" / mirror_host / upstream_path / rand_subdir
         )
-        self.assertEqual(
-            shutil_copytree.call_args,
-            call(
-                "{}/{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    snapshot_name,
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-            ),
+        exp_dst_root = (
+            self.harness.charm.base_path
+            / snapshot_name
+            / mirror_host
+            / upstream_path
+            / rand_subdir
         )
+        os_makedirs.assert_has_calls(
+            [
+                call(self.harness.charm.base_path / snapshot_name),
+                call(exp_dst_root, exist_ok=True),
+                call(exp_dst_root, exist_ok=True),
+            ]
+        )
+        os_symlink.assert_called_once_with(exp_src_root / "pool", exp_dst_root / "pool")
+        shutil_copytree.assert_called_once_with(exp_src_root / "dists", exp_dst_root / "dists")
 
     @patch("charm.open", new_callable=mock_open)
     @patch("os.walk")
@@ -448,7 +426,7 @@ deb fake-uri fake-distro\
         )
         default_config = self.harness.model.config
 
-        rand_subdir = random.randint(10, 100)
+        rand_subdir = str(random.randint(10, 100))
         upstream_path = "{}".format(uuid4())
         mirror_url = default_config["mirror-list"].split()[1]
         mirror_host = urlparse(mirror_url).hostname
@@ -466,49 +444,23 @@ deb fake-uri fake-distro\
         )
         os_path_exists.return_value = False
 
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._get_snapshot_name.return_value = snapshot_name
         self.harness.charm._on_create_snapshot_action(Mock())
-        self.assertTrue(os_symlink.called)
-        self.assertTrue(os_makedirs.called)
-        self.assertTrue(shutil_copytree.called)
-        self.assertEqual(
-            os_symlink.call_args,
-            call(
-                "{}/{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    snapshot_name,
-                    upstream_path,
-                    rand_subdir,
-                ),
-            ),
+        exp_src_root = (
+            self.harness.charm.base_path / "mirror" / mirror_host / upstream_path / rand_subdir
         )
-        self.assertEqual(
-            shutil_copytree.call_args,
-            call(
-                "{}/{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    snapshot_name,
-                    upstream_path,
-                    rand_subdir,
-                ),
-            ),
+        exp_dst_root = self.harness.charm.base_path / snapshot_name / upstream_path / rand_subdir
+        os_makedirs.assert_has_calls(
+            [
+                call(self.harness.charm.base_path / snapshot_name),
+                call(exp_dst_root, exist_ok=True),
+                call(exp_dst_root, exist_ok=True),
+            ]
         )
+        os_symlink.assert_called_once_with(exp_src_root / "pool", exp_dst_root / "pool")
+        shutil_copytree.assert_called_once_with(exp_src_root / "dists", exp_dst_root / "dists")
 
     @patch("charm.open", new_callable=mock_open)
     @patch("os.walk")
@@ -529,7 +481,7 @@ deb fake-uri fake-distro\
         )
         default_config = self.harness.model.config
 
-        rand_subdir = random.randint(10, 100)
+        rand_subdir = str(random.randint(10, 100))
         mirror_url = default_config["mirror-list"].split()[1]
         mirror_host = urlparse(mirror_url).hostname
         mirror_path = "{}/mirror".format(default_config["base-path"])
@@ -546,43 +498,23 @@ deb fake-uri fake-distro\
         )
         os_path_exists.return_value = False
 
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._get_snapshot_name.return_value = snapshot_name
         self.harness.charm._on_create_snapshot_action(Mock())
-        self.assertTrue(os_symlink.called)
-        self.assertTrue(os_makedirs.called)
-        self.assertTrue(shutil_copytree.called)
-        self.assertEqual(
-            os_symlink.call_args,
-            call(
-                "{}/{}/{}/{}/{}/pool".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/pool".format(
-                    default_config["base-path"], snapshot_name, mirror_host, rand_subdir
-                ),
-            ),
+        exp_src_root = (
+            self.harness.charm.base_path / "mirror" / mirror_host / upstream_path / rand_subdir
         )
-        self.assertEqual(
-            shutil_copytree.call_args,
-            call(
-                "{}/{}/{}/{}/{}/dists".format(
-                    default_config["base-path"],
-                    "mirror",
-                    mirror_host,
-                    upstream_path,
-                    rand_subdir,
-                ),
-                "{}/{}/{}/{}/dists".format(
-                    default_config["base-path"], snapshot_name, mirror_host, rand_subdir
-                ),
-            ),
+        exp_dst_root = self.harness.charm.base_path / snapshot_name / mirror_host / rand_subdir
+        os_makedirs.assert_has_calls(
+            [
+                call(self.harness.charm.base_path / snapshot_name),
+                call(exp_dst_root, exist_ok=True),
+                call(exp_dst_root, exist_ok=True),
+            ]
         )
+        os_symlink.assert_called_once_with(exp_src_root / "pool", exp_dst_root / "pool")
+        shutil_copytree.assert_called_once_with(exp_src_root / "dists", exp_dst_root / "dists")
 
     def test_list_snapshots_action(self):
         snapshot_name = "snapshot-{}".format(datetime.datetime.now().strftime("%Y%m%d%H%M%S"))
@@ -602,10 +534,7 @@ deb fake-uri fake-distro\
         snapshot_name = "snapshot-19700101"
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._on_delete_snapshot_action(Mock(params={"name": snapshot_name}))
-        self.assertEqual(
-            shutil_rmtree.call_args,
-            call("{}/{}".format(self.harness.model.config["base-path"], snapshot_name)),
-        )
+        shutil_rmtree.assert_called_once_with(self.harness.charm.base_path / snapshot_name)
 
     @patch("shutil.rmtree")
     def test_delete_snapshot_action_failure(self, shutil_rmtree):
@@ -630,17 +559,13 @@ deb fake-uri fake-distro\
         os_path_islink,
         os_path_isdir,
     ):
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         os_path_islink.return_value = True
-        base_path = self.harness.charm._stored.config["base-path"]
         self.harness.charm._get_snapshot_name = Mock()
         self.harness.charm._on_publish_snapshot_action(Mock(params={"name": snapshot_name}))
-        self.assertEqual(
-            os_symlink.call_args,
-            call(
-                "{}/{}".format(base_path, snapshot_name),
-                "{}/publish".format(base_path),
-            ),
+        os_symlink.assert_called_once_with(
+            self.harness.charm.base_path / snapshot_name,
+            self.harness.charm.base_path / "publish",
         )
 
     @patch("os.path.isdir")
@@ -650,7 +575,7 @@ deb fake-uri fake-distro\
     def test_publish_snapshot_action_fail(
         self, os_unlink, os_symlink, os_path_islink, os_path_isdir
     ):
-        snapshot_name = uuid4()
+        snapshot_name = str(uuid4())
         os_path_isdir.return_value = False
         action_event = Mock(params={"name": snapshot_name})
         self.harness.charm._get_snapshot_name = Mock()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -100,7 +100,27 @@ def test_get_package_indices(tmp_path, paths, exp_indices):
         _path.mkdir(parents=True, exist_ok=True)
         _path.touch()
 
-    assert utils._get_package_indices(dists) == [dists / indice for indice in exp_indices]
+    assert utils._get_package_indices(dists) == [dists / index for index in exp_indices]
+
+
+def test_get_archive_root_symlink():
+    """Test helper function to get root for pool."""
+    mock_path = MagicMock(spec_set=Path)
+    pool = mock_path("/a/b/c")
+    pool.is_symlink.return_value = True
+
+    archive_root = utils._get_archive_root(pool)
+    assert archive_root == pool.resolve.return_value.parent.absolute.return_value
+
+
+def test_get_archive_root():
+    """Test helper function to get root for pool."""
+    mock_path = MagicMock(spec_set=Path)
+    pool = mock_path("/a/b/c")
+    pool.is_symlink.return_value = False
+
+    archive_root = utils._get_archive_root(pool)
+    assert archive_root == pool.parent.absolute.return_value
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -49,6 +49,60 @@ def test_clean_packages(packages, exp_result):
         package.unlink.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "paths, exp_indices",
+    [
+        (
+            [
+                "bionic-backports/universe/binary-amd64/Packages.xz",
+                "bionic-backports/universe/binary-amd64/Packages.gz",
+                "bionic-backports/universe/binary-amd64/Packages",
+                "bionic-backports/main/binary-amd64/Packages.xz",
+                "bionic-backports/main/binary-amd64/Packages.gz",
+                "bionic-backports/main/binary-amd64/Packages",
+                "bionic-backports/multiverse/binary-amd64/Packages.xz",
+                "bionic-backports/multiverse/binary-amd64/Packages.gz",
+                "bionic-backports/multiverse/binary-amd64/Packages",
+                "bionic-backports/restricted/binary-amd64/Packages.xz",
+                "bionic-backports/restricted/binary-amd64/Packages.gz",
+                "bionic-backports/restricted/binary-amd64/Packages",
+                "focal-backports/universe/binary-amd64/Packages.xz",
+                "focal-backports/universe/binary-amd64/Packages.gz",
+                "focal-backports/universe/binary-amd64/Packages",
+                "focal-backports/main/binary-amd64/Packages.xz",
+                "focal-backports/main/binary-amd64/Packages.gz",
+                "focal-backports/main/binary-amd64/Packages",
+                "focal-backports/multiverse/binary-amd64/Packages.xz",
+                "focal-backports/multiverse/binary-amd64/Packages.gz",
+                "focal-backports/multiverse/binary-amd64/Packages",
+                "focal-backports/restricted/binary-amd64/Packages.xz",
+                "focal-backports/restricted/binary-amd64/Packages.gz",
+                "focal-backports/restricted/binary-amd64/Packages",
+            ],
+            [
+                "bionic-backports/main/binary-amd64/Packages",
+                "bionic-backports/multiverse/binary-amd64/Packages",
+                "bionic-backports/restricted/binary-amd64/Packages",
+                "bionic-backports/universe/binary-amd64/Packages",
+                "focal-backports/main/binary-amd64/Packages",
+                "focal-backports/multiverse/binary-amd64/Packages",
+                "focal-backports/restricted/binary-amd64/Packages",
+                "focal-backports/universe/binary-amd64/Packages",
+            ],
+        )
+    ],
+)
+def test_get_package_indices(tmp_path, paths, exp_indices):
+    """Test helper function to obtain package indices from dists directory."""
+    dists = tmp_path / "dists"
+    for path in paths:
+        _path = dists / path
+        _path.mkdir(parents=True, exist_ok=True)
+        _path.touch()
+
+    assert utils._get_package_indices(dists) == [dists / indice for indice in exp_indices]
+
+
 class TestUtils(unittest.TestCase):
     def test_find_packages_by_indices(self):
         """Test find_packages_by_indices on a sample mirror path."""


### PR DESCRIPTION
Add the _get_package_indices, which is searching all "**/Packages*" in dists, but instead of picking up only the first path, it's filtering a path from the same parent directory.