### PR TITLE
ci: Add workflow_call to check.yaml

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,7 @@
 name: Check workflow running lint checkers, unit and functional tests
 
 on:
+  workflow_call:
   pull_request:
     types: [ opened, synchronize, reopened ]
     branches: [ master, main ]


### PR DESCRIPTION
Since `on.workflow_call` was missing, the release workflow was failing as seen [here](https://github.com/canonical/charm-apt-mirror/actions/runs/7484717763).