### PR TITLE
Fix bug in convert_bytes

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -6,7 +6,7 @@
 import logging
 import shutil
 from pathlib import Path
-from typing import List, Set
+from typing import List, Set, Union
 
 logger = logging.getLogger(__name__)
 
@@ -102,12 +102,13 @@ def locate_package_indices(path):
     return zip(archive_roots, package_indices)
 
 
-def convert_bytes(num):
-    """Convert `num` of bytes to an appropriate unit."""
-    for unit in ["bytes", "KB", "MB", "GB", "TB"]:
+def convert_bytes(num: Union[int, float]) -> str:
+    """Convert `num` of bytes to a human readable value with unit."""
+    for unit in ["bytes", "KB", "MB", "GB"]:
         if num < 1024:
             return "{:.1f} {}".format(num, unit)
         num /= 1024
+    return "{:.1f} TB".format(num)
 
 
 def _locate_packages_from_index(package_index, archive_root=""):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -145,10 +145,16 @@ class TestUtils(unittest.TestCase):
 
     def test_convert_bytes(self):
         """Test convert_bytes on some sample bytes."""
-        units = ["bytes", "KB", "MB", "GB", "TB"]
         test_params = [
-            (1000 ** (i + 1), "{:.1f} {}".format(1000 ** (i + 1) / 1024 ** (i), unit))
-            for i, unit in zip(range(5), units)
+            (-1000000, "-1000000.0 bytes"),
+            (1000, "1000.0 bytes"),
+            (1000000, "976.6 KB"),
+            (1000000000, "953.7 MB"),
+            (1000000000000, "931.3 GB"),
+            (1000000000000000, "909.5 TB"),
+            ((1024**5) - 1, "1024.0 TB"),
+            (1024**5, "1024.0 TB"),
+            (1024**6, "1048576.0 TB"),
         ]
         for num, expected in test_params:
             with self.subTest():


### PR DESCRIPTION
For values >= 1024**5, `convert_bytes` would return None. Fix the bug, and update unit tests to cover these cases.